### PR TITLE
fixed git tag issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ bump-version setup.py --patch # bumps 1.2.3 -> 1.2.4
 # Use Git tag as version, e.g. v0.9-19-g7e2d
 bump-version setup.py --git
 
+# Force the use of git tag when current version is semantic
+bump-version setup.py --git --force
+
+# Force conversion from git tag to semantic version
+bump-version setup.py --patch --force
+
 # Pass several files to update
 bump-version setup.py README.md --patch
 ```
@@ -63,6 +69,7 @@ jobs:
         with:
           file: 'package.json' # file containing your package version number
           bump_type: 'patch'  # Options: major, minor, patch, git
+          force: true    # Optional: Force version change when current version is a git tag
 
       - name: Commit changes
         run: |
@@ -90,6 +97,7 @@ settings:
   files: # list of files to update
     - setup.py
     - README.md
+  force: false # Set to true to force version change when current version is a git tag
 ```
 
 In cli, pass the path to config file as an argument:
@@ -117,6 +125,14 @@ The tool recognizes uses regex to recognize various version patterns:
 
 - Invalid version format:
   - Reason: the tool could not find the version number. Your version possibly does not match supported patterns.
+
+- Current version is a git tag:
+  - Reason: You're trying to bump a version that is currently a git tag.
+  - Solution: Use the `--force` flag to convert it to a semantic version.
+
+- Current version is semantic:
+  - Reason: You're trying to replace a semantic version with a git tag.
+  - Solution: Use `--git --force` to replace the semantic version with a git tag.
 
 - File or permission errors:
   - Reason: the tool could not open or write to specified files.

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,13 @@ inputs:
     description: 'Comma-separated list of files to update version in (ignored if config is provided)'
     required: false
   bump_type:
-    description: 'Type of version bump (major/minor/patch) (ignored if config is provided)'
+    description: 'Type of version bump (major/minor/patch/git) (ignored if config is provided)'
     required: false
     default: 'patch'
+  force:
+    description: 'Force version change when current version is a git tag or when switching to git tag from semantic version'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -36,7 +40,26 @@ runs:
         FILES="${{ inputs.files }}"
         # Convert comma-separated list to space-separated for the CLI
         FILES="${FILES//,/ }"
-        simplebumpversion ${{ inputs.bump_type }} $FILES
+
+        # Handle force flag
+        FORCE_FLAG=""
+        if [[ "${{ inputs.force }}" == "true" ]]; then
+          FORCE_FLAG="--force"
+        fi
+
+        # Handle bump type
+        if [[ "${{ inputs.bump_type }}" == "major" ]]; then
+          bump-version $FILES --major $FORCE_FLAG
+        elif [[ "${{ inputs.bump_type }}" == "minor" ]]; then
+          bump-version $FILES --minor $FORCE_FLAG
+        elif [[ "${{ inputs.bump_type }}" == "patch" ]]; then
+          bump-version $FILES --patch $FORCE_FLAG
+        elif [[ "${{ inputs.bump_type }}" == "git" ]]; then
+          bump-version $FILES --git $FORCE_FLAG
+        else
+          # Default to patch
+          bump-version $FILES --patch $FORCE_FLAG
+        fi
 
 branding:
   icon: 'arrow-up'

--- a/bump_config.yml
+++ b/bump_config.yml
@@ -5,3 +5,4 @@ settings:
   bump_type: patch
   files: # list of files to update
     - pyproject.toml
+  force: false # Set to true to force version change when current version is a git tag

--- a/simplebumpversion/core/bump_version.py
+++ b/simplebumpversion/core/bump_version.py
@@ -102,7 +102,7 @@ def bump_semantic_version(
 
     if major:
         major_num += 1
-        minor_num = 1
+        minor_num = 0
         patch_num = 0
     elif minor:
         minor_num += 1

--- a/simplebumpversion/core/bump_version.py
+++ b/simplebumpversion/core/bump_version.py
@@ -25,28 +25,80 @@ def parse_semantic_version(version_str: str) -> Tuple[int, int, int]:
     return int(major), int(minor), int(patch)
 
 
+def is_git_tag_version(version_str: str) -> bool:
+    """
+    Check if a version string looks like a git tag.
+
+    Git tag versions typically include hyphens, commit hashes, etc.
+    Example: v0.9-19-g7e2d
+
+    Args:
+        version_str(str): The version string to check
+
+    Returns:
+        bool: True if it looks like a git tag, False otherwise
+    """
+    # Git tags often have this format: v0.9-19-g7e2d
+    # They frequently contain hyphens and letters not in the semantic version pattern
+    return "-" in version_str or (  # Contains hyphen
+        not re.match(r"^\d+\.\d+\.\d+$", version_str)  # Not a simple semantic version
+        and any(c.isalpha() for c in version_str)
+    )  # Contains letters
+
+
 def bump_semantic_version(
     current_version: str,
     major: bool = False,
     minor: bool = False,
     patch: bool = False,
     git_version: bool = False,
+    force: bool = False,
 ) -> str:
     """
     Bump the version according to the specified flags.
     Args:
         current_version(str): the current version as str, e.g. version=1.2.3
-        major(bool):
-        minor(bool):
-        patch(bool):
-        git_version(bool):
+        major(bool): bump major version
+        minor(bool): bump minor version
+        patch(bool): bump patch version
+        git_version(bool): use git tag as version
+        force(bool): force version change, even if current version is a git tag
     Returns:
         str: upgraded version as string, e.g. 1.2.4
+    Raises:
+        ValueError: If trying to use git tag on a semantic version without force flag
+                   or trying to change from git tag to semantic without force flag
     """
+    # Check if current version is a git tag
+    current_is_git_tag = is_git_tag_version(current_version)
+
+    # If user wants to use git version, return git tag
     if git_version:
+        # If current version is already semantic and force is not provided, raise error
+        if not current_is_git_tag and not force:
+            raise ValueError(
+                "Current version is semantic. Use --git --force to replace it with a git tag."
+            )
         return get_git_version()
 
-    major_num, minor_num, patch_num = parse_semantic_version(current_version)
+    # If current version is a git tag and we're trying to convert to semantic without force
+    if current_is_git_tag and not force:
+        raise ValueError(
+            "Current version is a git tag. Use --force to convert it to a semantic version."
+        )
+
+    # If current version is a git tag and force is provided, try to extract a semantic version
+    if current_is_git_tag and force:
+        # Try to extract semantic version from git tag
+        match = re.search(r"(\d+)\.(\d+)\.(\d+)", current_version)
+        if match:
+            major_num, minor_num, patch_num = map(int, match.groups())
+        else:
+            # If no semantic version found in git tag, default to 0.1.0
+            major_num, minor_num, patch_num = 0, 1, 0
+    else:
+        # Normal semantic version handling
+        major_num, minor_num, patch_num = parse_semantic_version(current_version)
 
     if major:
         major_num += 1
@@ -71,23 +123,41 @@ def find_version_in_file(file_path: str) -> Optional[str]:
     Returns:
         str|None: version number string or None
     Raises:
-        ValueError: version number pattern is not found in the file
+        NoValidVersionStr: version number pattern is not found in the file
     """
     content = read_file(file_path)
 
-    # Common version patterns
-    patterns = [
+    # Common semantic version patterns (strict semantic versioning)
+    semantic_patterns = [
         r'version\s*=\s*["\'](\d+\.\d+\.\d+)["\']',  # version = "1.2.3"
         r'VERSION\s*=\s*["\'](\d+\.\d+\.\d+)["\']',  # VERSION = "1.2.3"
         r'__version__\s*=\s*["\'](\d+\.\d+\.\d+)["\']',  # __version__ = "1.2.3"
         r'"version"\s*:\s*"(\d+\.\d+\.\d+)"',  # "version": "1.2.3"
     ]
+
+    # More flexible patterns that can match git tags or other version formats
+    flexible_patterns = [
+        r'version\s*=\s*["\']([\w\.\-]+)["\']',  # version = "v1.2.3-19-gabc123"
+        r'VERSION\s*=\s*["\']([\w\.\-]+)["\']',  # VERSION = "v1.2.3-19-gabc123"
+        r'__version__\s*=\s*["\']([\w\.\-]+)["\']',  # __version__ = "v1.2.3-19-gabc123"
+        r'"version"\s*:\s*"([\w\.\-]+)"',  # "version": "v1.2.3-19-gabc123"
+    ]
+
+    # First try to find a semantic version
     version = None
-    for pattern in patterns:
+    for pattern in semantic_patterns:
         match = re.search(pattern, content)
         if match:
             version = match.group(1)
             break
+
+    # If no semantic version found, try flexible patterns that can match git tags
+    if version is None:
+        for pattern in flexible_patterns:
+            match = re.search(pattern, content)
+            if match:
+                version = match.group(1)
+                break
 
     if version is None:
         raise NoValidVersionStr(f"Error: No version found in {file_path}")
@@ -107,7 +177,7 @@ def update_version_in_file(file_path: str, old_version: str, new_version: str) -
     """
     content = read_file(file_path)
 
-    # Common version patterns to replace
+    # Common version patterns to replace, works for both semantic versions and git tags
     patterns = [
         (
             f"version\\s*=\\s*[\"']({re.escape(old_version)})[\"']",

--- a/simplebumpversion/core/config_handler.py
+++ b/simplebumpversion/core/config_handler.py
@@ -6,6 +6,7 @@ config_desc_key = "description"
 settings_key = "settings"
 bump_type_key = "bump_type"
 files_key = "files"
+force_key = "force"
 
 
 def open_config_file(config_path: os.PathLike) -> dict:
@@ -37,7 +38,7 @@ def validate_config(config: dict) -> bool:
 
 def parse_config_arguments(
     config_path: os.PathLike,
-) -> tuple[list[str], bool, bool, bool, bool]:
+) -> tuple[list[str], bool, bool, bool, bool, bool]:
     """
     Parse the arguments in the config file
     Args:
@@ -61,7 +62,11 @@ def parse_config_arguments(
     is_minor, is_patch, is_git = get_bump_flags(bump_type)
     is_major = False
     files = config[settings_key][files_key]
-    return files, is_major, is_minor, is_patch, is_git
+    # Check if force flag is provided in config
+    is_force = False
+    if force_key in config[settings_key]:
+        is_force = bool(config[settings_key][force_key])
+    return files, is_major, is_minor, is_patch, is_git, is_force
 
 
 def get_bump_flags(bump_type: str) -> list[bool, bool, bool]:

--- a/simplebumpversion/core/parse_arguments.py
+++ b/simplebumpversion/core/parse_arguments.py
@@ -6,23 +6,25 @@ from simplebumpversion.core.exceptions import ArgumentsNotFound
 
 def parse_cli_arguments(
     args: argparse.Namespace,
-) -> tuple[list, bool, bool, bool, bool]:
+) -> tuple[list, bool, bool, bool, bool, bool]:
     """
     Parse command line arguments from argparse.Namespace object
     Args:
         args(argparse.Namespace):
     Returns:
-        tuple(list, bool, bool, bool, bool):
+        tuple(list, bool, bool, bool, bool, bool):
         tuple containing parsed arguments with file names and bump type flags
     """
     if not args.file:
         raise ArgumentsNotFound(
             f"At least one file path must be provided when not using a config file"
         )
-    return args.file, args.major, args.minor, args.patch, args.git
+    return args.file, args.major, args.minor, args.patch, args.git, args.force
 
 
-def parse_arguments(args: argparse.Namespace) -> tuple[list, bool, bool, bool, bool]:
+def parse_arguments(
+    args: argparse.Namespace,
+) -> tuple[list, bool, bool, bool, bool, bool]:
     """
     Wrapper function to parse arguments from various sources.
     Args:
@@ -35,7 +37,7 @@ def parse_arguments(args: argparse.Namespace) -> tuple[list, bool, bool, bool, b
     """
     # check if config is given
     if args.config:
-        if args.file or args.minor or args.patch or args.git:
+        if args.file or args.minor or args.patch or args.git or args.force:
             warnings.warn(
                 "Only one of config file or \
                         cli arguments are needed. Ignoring cli arguments."

--- a/simplebumpversion/main.py
+++ b/simplebumpversion/main.py
@@ -8,6 +8,7 @@ from simplebumpversion.core.bump_version import (
     bump_semantic_version,
     update_version_in_file,
 )
+from simplebumpversion.core.exceptions import NoValidVersionStr
 
 
 def main():

--- a/simplebumpversion/main.py
+++ b/simplebumpversion/main.py
@@ -18,7 +18,16 @@ def main():
     parser.add_argument("--major", action="store_true", help="Bump major version")
     parser.add_argument("--minor", action="store_true", help="Bump minor version")
     parser.add_argument("--patch", action="store_true", help="Bump patch version")
-    parser.add_argument("--git", action="store_true", help="Use git tag as version")
+    parser.add_argument(
+        "--git",
+        action="store_true",
+        help="Use git tag as version (requires --force if current version is semantic)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force version change when current version is a git tag or when switching from semantic to git tag",
+    )
     parser.add_argument(
         "--config", help="Load settings from a config file. Overrides cli arguments"
     )
@@ -30,7 +39,7 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    target_files, is_major, is_minor, is_patch, is_git = parse_arguments(args)
+    target_files, is_major, is_minor, is_patch, is_git, is_force = parse_arguments(args)
 
     # iterate the target files, check if they exist
     for file in target_files:
@@ -39,20 +48,32 @@ def main():
             print(f"Error: File '{file}' not found")
             return 1
 
-        current_version = find_version_in_file(file)
+        try:
+            current_version = find_version_in_file(file)
 
-        new_version = bump_semantic_version(
-            current_version,
-            major=is_major,
-            minor=is_minor,
-            patch=is_patch,
-            git_version=is_git,
-        )
+            try:
+                new_version = bump_semantic_version(
+                    current_version,
+                    major=is_major,
+                    minor=is_minor,
+                    patch=is_patch,
+                    git_version=is_git,
+                    force=is_force,
+                )
 
-        if update_version_in_file(file, current_version, new_version):
-            print(f"Version bumped from {current_version} to {new_version}")
-        else:
-            print(f"Error: Failed to update version in '{file}'")
+                if update_version_in_file(file, current_version, new_version):
+                    print(f"Version bumped from {current_version} to {new_version}")
+                else:
+                    print(f"Error: Failed to update version in '{file}'")
+                    return 1
+
+            except ValueError as e:
+                print(f"Error: {str(e)}")
+                return 1
+
+        except NoValidVersionStr as e:
+            print(f"{str(e)}")
+            return 1
 
 
 if __name__ == "__main__":

--- a/test/test_bump_version.py
+++ b/test/test_bump_version.py
@@ -1,0 +1,130 @@
+import os
+import re
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+from simplebumpversion.core.bump_version import (
+    parse_semantic_version,
+    bump_semantic_version,
+    find_version_in_file,
+    update_version_in_file,
+    is_git_tag_version,
+)
+
+
+class TestBumpVersion(unittest.TestCase):
+    def test_parse_semantic_version(self):
+        major, minor, patch = parse_semantic_version("1.2.3")
+        self.assertEqual(major, 1)
+        self.assertEqual(minor, 2)
+        self.assertEqual(patch, 3)
+
+        with self.assertRaises(ValueError):
+            parse_semantic_version("invalid")
+
+    def test_bump_semantic_version(self):
+        # Test patch bump
+        new_version = bump_semantic_version("1.2.3", patch=True)
+        self.assertEqual(new_version, "1.2.4")
+
+        # Test minor bump
+        new_version = bump_semantic_version("1.2.3", minor=True)
+        self.assertEqual(new_version, "1.3.0")
+
+        # Test major bump
+        new_version = bump_semantic_version("1.2.3", major=True)
+        self.assertEqual(new_version, "2.1.0")
+
+        # Test default (patch) bump
+        new_version = bump_semantic_version("1.2.3")
+        self.assertEqual(new_version, "1.2.4")
+
+    def test_git_tag_detection(self):
+        # Test git tag detection
+        self.assertTrue(is_git_tag_version("v0.9-19-g7e2d"))
+        self.assertTrue(is_git_tag_version("1.2.3-alpha.1"))
+        self.assertFalse(is_git_tag_version("1.2.3"))
+
+    def test_git_version_behavior(self):
+        # Instead of testing the actual return value, let's just test the behavior
+        # Test with semantic version without force
+        with self.assertRaises(ValueError):
+            bump_semantic_version("1.2.3", git_version=True)
+
+        # Test with semantic version with force - should not raise error
+        try:
+            new_version = bump_semantic_version("1.2.3", git_version=True, force=True)
+            # Just verify it's a git tag format (contains hyphen or not pure semantic)
+            self.assertTrue(is_git_tag_version(new_version))
+        except ValueError:
+            self.fail("bump_semantic_version with force raised ValueError unexpectedly")
+
+        # Test with git tag without force (should work)
+        try:
+            new_version = bump_semantic_version("v0.9-19-g7e2d", git_version=True)
+            # Just verify it's a git tag format
+            self.assertTrue(is_git_tag_version(new_version))
+        except ValueError:
+            self.fail(
+                "bump_semantic_version with git tag raised ValueError unexpectedly"
+            )
+
+    def test_force_conversion(self):
+        # Test git tag to semantic without force
+        with self.assertRaises(ValueError):
+            bump_semantic_version("v0.9-19-g7e2d", patch=True)
+
+        # Test git tag to semantic with force and a recognizable version
+        new_version = bump_semantic_version("v0.9-19-g7e2d", patch=True, force=True)
+        # We'll just check if it's a semantic version now (don't test exact value)
+        self.assertTrue(re.match(r"^\d+\.\d+\.\d+$", new_version))
+
+        # Test git tag without clear semantic version
+        new_version = bump_semantic_version("tag-v1", patch=True, force=True)
+        # It should use default 0.1.0 and bump to 0.1.1
+        self.assertEqual(new_version, "0.1.1")
+
+    def test_find_and_update_version(self):
+        # Create temporary files with different version formats
+        temp_files = []
+
+        # Semantic version file
+        semantic_file = tempfile.NamedTemporaryFile(delete=False)
+        semantic_file.write(b'version = "1.2.3"')
+        semantic_file.close()
+        temp_files.append(semantic_file.name)
+
+        # Git tag version file
+        git_tag_file = tempfile.NamedTemporaryFile(delete=False)
+        git_tag_file.write(b'version = "v0.9-19-g7e2d"')
+        git_tag_file.close()
+        temp_files.append(git_tag_file.name)
+
+        try:
+            # Test finding semantic version
+            version = find_version_in_file(semantic_file.name)
+            self.assertEqual(version, "1.2.3")
+
+            # Test finding git tag version
+            version = find_version_in_file(git_tag_file.name)
+            self.assertEqual(version, "v0.9-19-g7e2d")
+
+            # Test updating semantic version
+            updated = update_version_in_file(semantic_file.name, "1.2.3", "1.2.4")
+            self.assertTrue(updated)
+
+            # Test updating git tag version
+            updated = update_version_in_file(
+                git_tag_file.name, "v0.9-19-g7e2d", "1.0.0"
+            )
+            self.assertTrue(updated)
+
+        finally:
+            # Clean up temp files
+            for file_path in temp_files:
+                if os.path.exists(file_path):
+                    os.unlink(file_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  1. Added detection for git tag versions with the is_git_tag_version function
  2. Added --force flag to CLI and config options
  3. Updated bump_semantic_version to handle:
    - Converting from semantic version to git tag (requires force)
    - Converting from git tag to semantic version (requires force)
    - Extracting semantic version from git tag when possible
  4. Updated find_version_in_file to recognize git tag version formats
  5. Made update_version_in_file work with both semantic and git tag versions
  6. Added error handling and clear error messages in the main function
  7. Updated documentation in README.md
  8. Added test cases to verify the new functionality

  These changes ensure that:
  1. If the current version is semantic and user passes --git, it will fail unless --force is also provided
  2. If the current version is a git tag and user tries to bump it, it will fail unless --force is provided
  3. Proper error messages are shown to guide the user on how to proceed