### PR TITLE
added change-logger

### DIFF
--- a/bump_config.yml
+++ b/bump_config.yml
@@ -1,8 +1,8 @@
-name: 'Patch bump' # Configuration name
-description: 'Bump the patch version' # description
-
+name: Patch bump
+description: Bump the patch version
 settings:
   bump_type: patch
-  files: # list of files to update
-    - pyproject.toml
-  force: false # Set to true to force version change when current version is a git tag
+  files:
+  - pyproject.toml
+  force: false
+  change_log_file: CHANGELOG.md

--- a/simplebumpversion/core/bump_version.py
+++ b/simplebumpversion/core/bump_version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import re
 from typing import Optional, Tuple
-from simplebumpversion.core.git_tools import get_git_version
+from simplebumpversion.core.git_tools import get_git_version, get_latest_git_tag
 from simplebumpversion.core.file_handler import read_file, write_to_file
 from simplebumpversion.core.exceptions import NoValidVersionStr
 
@@ -73,13 +73,13 @@ def bump_semantic_version(
     current_is_git_tag = is_git_tag_version(current_version)
 
     # If user wants to use git version, return git tag
-    if git_version:
-        # If current version is already semantic and force is not provided, raise error
-        if not current_is_git_tag and not force:
-            raise ValueError(
-                "Current version is semantic. Use --git --force to replace it with a git tag."
-            )
-        return get_git_version()
+    # if git_version:
+    #     # If current version is already semantic and force is not provided, raise error
+    #     if not current_is_git_tag and not force:
+    #         raise ValueError(
+    #             "Current version is semantic. Use --git --force to replace it with a git tag."
+    #         )
+    #     return get_latest_git_tag()
 
     # If current version is a git tag and we're trying to convert to semantic without force
     if current_is_git_tag and not force:
@@ -99,7 +99,6 @@ def bump_semantic_version(
     else:
         # Normal semantic version handling
         major_num, minor_num, patch_num = parse_semantic_version(current_version)
-
     if major:
         major_num += 1
         minor_num = 0

--- a/simplebumpversion/core/change_logger.py
+++ b/simplebumpversion/core/change_logger.py
@@ -1,0 +1,19 @@
+import os
+from datetime import datetime
+import subprocess
+import re
+
+
+def write_changelog(new_version, changelog_path, message, update_type):
+    new_entry = f"## {new_version} - {datetime.now().strftime('%Y-%m-%d')} [ {update_type} ]\n\n"
+    new_entry += "\n".join(f"- {line}" for line in message.strip().splitlines())
+    new_entry += "\n\n"
+
+    if os.path.exists(changelog_path):
+        with open(changelog_path, "r") as f:
+            old_content = f.read()
+    else:
+        old_content = ""
+
+    with open(changelog_path, "w") as f:
+        f.write(new_entry + old_content)

--- a/simplebumpversion/core/config_handler.py
+++ b/simplebumpversion/core/config_handler.py
@@ -7,6 +7,7 @@ settings_key = "settings"
 bump_type_key = "bump_type"
 files_key = "files"
 force_key = "force"
+change_log_file_key = "change_log_file"
 
 
 def open_config_file(config_path: os.PathLike) -> dict:
@@ -24,6 +25,11 @@ def open_config_file(config_path: os.PathLike) -> dict:
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
     return config
+
+
+def write_config_file(config_path, config):
+    with open(config_path, "w") as f:
+        yaml.dump(config, f, sort_keys=False)
 
 
 def validate_config(config: dict) -> bool:
@@ -94,3 +100,24 @@ def get_bump_flags(bump_type: str) -> list[bool, bool, bool]:
         is_patch = True
 
     return is_minor, is_patch, is_git
+
+
+def get_change_log_file(config_path):
+    config = open_config_file(config_path)
+    change_log_file = config[settings_key][change_log_file_key]
+    return change_log_file
+
+
+def set_change_log_file(config_path, new_name):
+    config = open_config_file(config_path)
+    config[settings_key][change_log_file_key] = new_name
+    write_config_file(config_path, config)
+
+
+if __name__ == "__main__":
+    conf_dir = "/home/wsl/projects/forks/bump_version/bump_config.yml"
+    f = get_change_log_file(conf_dir)
+    print(f)
+    set_change_log_file(conf_dir, "new_config.md")
+    f = get_change_log_file(conf_dir)
+    print(f)

--- a/simplebumpversion/core/git_tools.py
+++ b/simplebumpversion/core/git_tools.py
@@ -17,7 +17,7 @@ def get_git_version() -> str:
     try:
         # Get the most recent tag
         result = subprocess.run(
-            ["git", "describe", "--tags", "--abbrev=1"],
+            ["git", "describe", "--tags", "--abbrev=0"],
             check=True,
             capture_output=True,
             text=True,
@@ -25,3 +25,59 @@ def get_git_version() -> str:
         return result.stdout.strip()
     except subprocess.CalledProcessError:
         raise ValueError("Error occured when reading the git tag")
+
+
+def update_git_tag(new_version, msg=None):
+    try:
+        if msg is not None:
+            subprocess.run(["git", "tag", "-a", new_version, "-m", msg], check=True)
+        else:
+            subprocess.run(
+                ["git", "tag", "-a", new_version, "-m", f"Tag {new_version}"],
+                check=True,
+            )
+        print(f"Tag '{new_version}' created successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to create git tag '{new_version}'.")
+        print(e)
+
+
+def get_latest_git_tag():
+    try:
+        return (
+            subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
+            .decode()
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+
+def get_commits_since_tag(tag):
+    try:
+        log_range = f"{tag}..HEAD" if tag else "HEAD"
+        output = (
+            subprocess.check_output(["git", "log", log_range, "--oneline"])
+            .decode()
+            .strip()
+        )
+        commits = output.splitlines()
+        result = "\n".join(commits) if commits else None
+        return result
+    except subprocess.CalledProcessError:
+        print("Error while fetching commits since last tag")
+
+
+def if_any_updates():
+    last_tag = get_latest_git_tag()
+    commits = get_commits_since_tag(last_tag)
+    return True if commits else False
+
+
+if __name__ == "__main__":
+    # tag = get_git_version()
+    tag = get_latest_git_tag()
+    print("Last tag:", tag)
+
+    commits = get_commits_since_tag(tag)
+    print("Commits since tag:", commits)

--- a/test/test_bump_version.py
+++ b/test/test_bump_version.py
@@ -1,4 +1,7 @@
 import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import re
 import tempfile
 import unittest


### PR DESCRIPTION
Done: 

- on bump_version it will create/update CHANGELOG.md with list of commits since last git tag
- pass changes.md file with changes after --change_msg_file and it that will be written in CHANGELOG instead of commits since last tag
- you can pass inline message with --change_msg too
