### PR TITLE
Fixed unit tests and added support for version strings prefixed with 'v'

### DIFF
--- a/simplebumpversion/core/bump_version.py
+++ b/simplebumpversion/core/bump_version.py
@@ -17,7 +17,9 @@ def parse_semantic_version(version_str: str) -> Tuple[int, int, int]:
     Raises:
         ValueError:
     """
-    match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str)
+    match = re.fullmatch(
+        r"v?(\d+)\.(\d+)\.(\d+)", version_str
+    )  # supports both 1.2.3 and v.1.2.3 formats
     if not match:
         raise ValueError(f"Invalid version format: {version_str}")
 
@@ -59,8 +61,15 @@ def bump_semantic_version(
     Returns:
         str: upgraded version as string, e.g. 1.2.4
     """
+    has_v_prefix = current_version.startswith("v")
     # Normal semantic version handling
-    major_num, minor_num, patch_num = parse_semantic_version(current_version)
+    try:
+        major_num, minor_num, patch_num = parse_semantic_version(current_version)
+    except ValueError:
+        raise ValueError(
+            f"Cannot bump version: '{current_version}' is not a valid semantic version (e.g. '1.2.3')"
+        )
+
     if major:
         major_num += 1
         minor_num = 0
@@ -73,7 +82,8 @@ def bump_semantic_version(
     else:  # update patch number if all flags are false
         patch_num += 1
 
-    return f"{major_num}.{minor_num}.{patch_num}"
+    bumped_version = f"{major_num}.{minor_num}.{patch_num}"
+    return f"v{bumped_version}" if has_v_prefix else bumped_version
 
 
 def find_version_in_file(file_path: str) -> str:

--- a/test/test_bump_version.py
+++ b/test/test_bump_version.py
@@ -14,119 +14,90 @@ from simplebumpversion.core.bump_version import (
     is_git_tag_version,
 )
 
+from simplebumpversion.core.exceptions import NoValidVersionStr
+
 
 class TestBumpVersion(unittest.TestCase):
     def test_parse_semantic_version(self):
         major, minor, patch = parse_semantic_version("1.2.3")
-        self.assertEqual(major, 1)
-        self.assertEqual(minor, 2)
-        self.assertEqual(patch, 3)
+        self.assertEqual((major, minor, patch), (1, 2, 3))
 
         with self.assertRaises(ValueError):
-            parse_semantic_version("invalid")
+            parse_semantic_version("not-a-version")
+
+        with self.assertRaises(ValueError):
+            parse_semantic_version("v1.2.3-19-g123abc")
 
     def test_bump_semantic_version(self):
-        # Test patch bump
-        new_version = bump_semantic_version("1.2.3", patch=True)
-        self.assertEqual(new_version, "1.2.4")
+        self.assertEqual(bump_semantic_version("1.2.3", patch=True), "1.2.4")
+        self.assertEqual(bump_semantic_version("1.2.3", minor=True), "1.3.0")
+        self.assertEqual(bump_semantic_version("1.2.3", major=True), "2.0.0")
+        self.assertEqual(bump_semantic_version("1.2.3"), "1.2.4")
 
-        # Test minor bump
-        new_version = bump_semantic_version("1.2.3", minor=True)
-        self.assertEqual(new_version, "1.3.0")
+        self.assertEqual(bump_semantic_version("v1.2.3", patch=True), "v1.2.4")
+        self.assertEqual(bump_semantic_version("v1.2.3", minor=True), "v1.3.0")
+        self.assertEqual(bump_semantic_version("v1.2.3", major=True), "v2.0.0")
+        self.assertEqual(bump_semantic_version("v1.2.3"), "v1.2.4")
 
-        # Test major bump
-        new_version = bump_semantic_version("1.2.3", major=True)
-        self.assertEqual(new_version, "2.1.0")
+        # Test invalid input
+        with self.assertRaises(ValueError):
+            bump_semantic_version("v1.2.3-19-g7e2d", patch=True)
 
-        # Test default (patch) bump
-        new_version = bump_semantic_version("1.2.3")
-        self.assertEqual(new_version, "1.2.4")
-
-    def test_git_tag_detection(self):
-        # Test git tag detection
+    def test_is_git_tag_version(self):
         self.assertTrue(is_git_tag_version("v0.9-19-g7e2d"))
-        self.assertTrue(is_git_tag_version("1.2.3-alpha.1"))
+        self.assertTrue(is_git_tag_version("1.2.3-alpha"))
         self.assertFalse(is_git_tag_version("1.2.3"))
+        self.assertTrue(is_git_tag_version("release-2023"))
 
-    def test_git_version_behavior(self):
-        # Instead of testing the actual return value, let's just test the behavior
-        # Test with semantic version without force
-        with self.assertRaises(ValueError):
-            bump_semantic_version("1.2.3", git_version=True)
+    def test_find_version_in_file(self):
+        with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmp:
+            tmp.write('__version__ = "1.2.3"\n')
+            tmp.flush()
+            found = find_version_in_file(tmp.name)
+            self.assertEqual(found, "1.2.3")
 
-        # Test with semantic version with force - should not raise error
-        try:
-            new_version = bump_semantic_version("1.2.3", git_version=True, force=True)
-            # Just verify it's a git tag format (contains hyphen or not pure semantic)
-            self.assertTrue(is_git_tag_version(new_version))
-        except ValueError:
-            self.fail("bump_semantic_version with force raised ValueError unexpectedly")
+        with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmp:
+            tmp.write('version = "v0.9-19-g7e2d"\n')
+            tmp.flush()
+            found = find_version_in_file(tmp.name)
+            self.assertEqual(found, "v0.9-19-g7e2d")
 
-        # Test with git tag without force (should work)
-        try:
-            new_version = bump_semantic_version("v0.9-19-g7e2d", git_version=True)
-            # Just verify it's a git tag format
-            self.assertTrue(is_git_tag_version(new_version))
-        except ValueError:
-            self.fail(
-                "bump_semantic_version with git tag raised ValueError unexpectedly"
-            )
+        with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmp:
+            tmp.write("no version here\n")
+            tmp.flush()
+            with self.assertRaises(NoValidVersionStr):
+                find_version_in_file(tmp.name)
 
-    def test_force_conversion(self):
-        # Test git tag to semantic without force
-        with self.assertRaises(ValueError):
-            bump_semantic_version("v0.9-19-g7e2d", patch=True)
-
-        # Test git tag to semantic with force and a recognizable version
-        new_version = bump_semantic_version("v0.9-19-g7e2d", patch=True, force=True)
-        # We'll just check if it's a semantic version now (don't test exact value)
-        self.assertTrue(re.match(r"^\d+\.\d+\.\d+$", new_version))
-
-        # Test git tag without clear semantic version
-        new_version = bump_semantic_version("tag-v1", patch=True, force=True)
-        # It should use default 0.1.0 and bump to 0.1.1
-        self.assertEqual(new_version, "0.1.1")
-
-    def test_find_and_update_version(self):
-        # Create temporary files with different version formats
-        temp_files = []
-
-        # Semantic version file
-        semantic_file = tempfile.NamedTemporaryFile(delete=False)
-        semantic_file.write(b'version = "1.2.3"')
-        semantic_file.close()
-        temp_files.append(semantic_file.name)
-
-        # Git tag version file
-        git_tag_file = tempfile.NamedTemporaryFile(delete=False)
-        git_tag_file.write(b'version = "v0.9-19-g7e2d"')
-        git_tag_file.close()
-        temp_files.append(git_tag_file.name)
-
-        try:
-            # Test finding semantic version
-            version = find_version_in_file(semantic_file.name)
-            self.assertEqual(version, "1.2.3")
-
-            # Test finding git tag version
-            version = find_version_in_file(git_tag_file.name)
-            self.assertEqual(version, "v0.9-19-g7e2d")
-
-            # Test updating semantic version
-            updated = update_version_in_file(semantic_file.name, "1.2.3", "1.2.4")
-            self.assertTrue(updated)
-
-            # Test updating git tag version
+    def test_update_version_in_file(self):
+        with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmp:
+            tmp.write('__version__ = "1.2.3"\n')
+            tmp.flush()
             updated = update_version_in_file(
-                git_tag_file.name, "v0.9-19-g7e2d", "1.0.0"
+                tmp.name, "1.2.3", "1.2.4", is_dry_run=False
             )
             self.assertTrue(updated)
+            with open(tmp.name) as f:
+                content = f.read()
+            self.assertIn("1.2.4", content)
 
-        finally:
-            # Clean up temp files
-            for file_path in temp_files:
-                if os.path.exists(file_path):
-                    os.unlink(file_path)
+        with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmp:
+            tmp.write('version = "v0.9-19-g7e2d"\n')
+            tmp.flush()
+            updated = update_version_in_file(
+                tmp.name, "v0.9-19-g7e2d", "1.0.0", is_dry_run=False
+            )
+            self.assertTrue(updated)
+            with open(tmp.name) as f:
+                content = f.read()
+            self.assertIn("1.0.0", content)
+
+        with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmp:
+            tmp.write('version = "1.2.3"\n')
+            tmp.flush()
+            updated = update_version_in_file(
+                tmp.name, "9.9.9", "1.2.4", is_dry_run=False
+            )
+            self.assertFalse(updated)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed unit tests for refactored code with changelog feature and added support for version with prefix v (e.g. v1.2.3)